### PR TITLE
upgrade shebang to python3, add __main__ check

### DIFF
--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import absolute_import
+#!/usr/bin/env python3
 
 import argparse
 import datetime
@@ -1457,8 +1455,8 @@ def get_arguments():
         metavar = 'DPI',
         help = "DPI of the SVG file (int)",
         default = DEFAULT_DPI,
-    )    
-    
+    )
+
     parser.add_argument(
         '--center',
         dest = 'center',
@@ -1474,8 +1472,8 @@ def get_arguments():
     #------------------------------------------------------------------------
 
 #----------------------------------------------------------------------------
-
-main()
+if __name__ == "__main__":
+    main()
 
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
1. Adds shebang for python3, taking the current env into account. Instead of using ```/usr/bin/python``` which could be either python 2 or 3 depending on the system ```/usr/bin/env python3``` will always point to python 3, and will also resolve to the local version of python when using a virtual environment . 
2. Removes unneeded import from futures (as we are already using Python 3).
3. Adds ```__name__``` check to make sure we only run the script when we want (prevents running any code when we are importing the the module instead of running it directly). 

This last change also seems to fix the problem of the script running twice, which it seems to do now (see below screenshot):

![image](https://user-images.githubusercontent.com/734644/81224014-4e2cd600-8fe7-11ea-921f-4112dde5810c.png)


### After the update:
![image](https://user-images.githubusercontent.com/734644/81224773-84b72080-8fe8-11ea-961b-38a5aca362b6.png)


