### PR TITLE
Add option to skip hidden layers

### DIFF
--- a/svg2mod/svg/svg/svg.py
+++ b/svg2mod/svg/svg/svg.py
@@ -260,12 +260,16 @@ class Group(Transformable):
         Transformable.__init__(self, elt)
 
         self.name = ""
+        self.hidden = False
         if elt is not None:
             for id, value in elt.attrib.items():
 
                 id = self.parse_name( id )
                 if id[ "name" ] == "label":
                     self.name = value
+                if id[ "name" ] == "style":
+                    if re.search( "display\s*:\s*none", value ):
+                        self.hidden = True
 
     @staticmethod
     def parse_name( tag ):


### PR DESCRIPTION
Pass `-x` to omit from the export those layers that are marked as hidden.

This patch is an alternative to #6, and is verbose in a different way. This time the hidden layers are removed immediately after the import. `_prune_hidden` is largely based on `_prune`, which is not very elegant.