### PR TITLE
Recursively attempt to insert segments

### DIFF
--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -321,7 +321,7 @@ class PolygonSegment( object ):
     def inline( self, segments ):
 
         if len( segments ) < 1:
-            return self.points
+            return self.points, []
 
         if self.verbose:
             print( "    Inlining {} segments...".format( len( segments ) ) )
@@ -337,6 +337,7 @@ class PolygonSegment( object ):
             )
             if insertion is not None:
                 insertions.append( insertion )
+                segments.remove( hole )
 
         insertions.sort( key = lambda i: i[ 0 ] )
 
@@ -367,7 +368,7 @@ class PolygonSegment( object ):
             inlined.append( points[ ip ] )
             ip += 1
 
-        return inlined
+        return inlined, segments
 
 
     #------------------------------------------------------------------------
@@ -667,7 +668,12 @@ class Svg2ModExport( object ):
                     segment.process( self, flip, fill )
 
                 if len( segments ) > 1:
-                    points = segments[ 0 ].inline( segments[ 1 : ] )
+                    holes = segments[ 1 : ]
+                    giveup = 0
+                    while ( len( holes ) and giveup < 5 ):
+                        points, holes = segments[ 0 ].inline( holes )
+                        segments[ 0 ].points = points
+                        giveup += 1
 
                 elif len( segments ) > 0:
                     points = segments[ 0 ].points

--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -287,10 +287,8 @@ class PolygonSegment( object ):
                     # is acceptable:
                     return ( cp, hole.points_starting_on_index( hp ) )
 
-        print(
-            "\033[91mCould not insert segment without overlapping other segments\033[0m",
-            file=sys.stderr
-        )
+        if self.verbose:
+            print("      Could not insert segment without overlapping other segments")
 
 
     #------------------------------------------------------------------------
@@ -674,6 +672,12 @@ class Svg2ModExport( object ):
                         points, holes = segments[ 0 ].inline( holes )
                         segments[ 0 ].points = points
                         giveup += 1
+
+                    if len(holes):
+                        print(
+                            "\033[91mCould not insert segment without overlapping other segments, after {} attempts\033[0m".format(giveup),
+                            file=sys.stderr
+                        )
 
                 elif len( segments ) > 0:
                     points = segments[ 0 ].points


### PR DESCRIPTION
My design has a rectangle of copper with some holes in it, which was throwing "Could not insert segment without overlapping other segments" errors, possibly because the outer rectangle has only four points to branch from. I changed the script to do multiple passes, so more insertion points can be found.

In my case, this fixed the problem perfectly, but I have not tested it on any other designs.