### PR TITLE
Fix conversion of files without viewBox

### DIFF
--- a/svg2mod/svg/svg/svg.py
+++ b/svg2mod/svg/svg/svg.py
@@ -209,7 +209,7 @@ class Svg(Transformable):
     # tag = 'svg'
 
     def __init__(self, filename=None, verbose=True):
-        viewport_scale = 1
+        self.viewport_scale = 1
         Transformable.__init__(self, verbose=verbose)
         if filename:
             self.parse(filename)


### PR DESCRIPTION
In commit 664ee86 (Fix verbose flag and stroke width calulation) a new
`viewport_scale` variable was introduced into the Svg class. However,
the default value set in the constructor lacked a `self.` prefix, so
this attribute would not be set by default. On files with a `viewBox`
element, this attribute would be set later, but files without this would
lack the attribute and break:

    File "svg2mod/svg2mod.py", line 538, in _get_fill_stroke
       scale = self.imported.svg.viewport_scale * float(self.dpi) / 25.4
    AttributeError: 'Svg' object has no attribute 'viewport_scale'