### PR TITLE
svg.text: Pass through glyphSet not method

### DIFF
--- a/svg2mod/svg/svg.py
+++ b/svg2mod/svg/svg.py
@@ -1355,7 +1355,7 @@ class Text(Transformable):
                     #txt = txt.replace(char, "")
                     continue
 
-                pen = SVGPathPen(ttf.getGlyphSet)
+                pen = SVGPathPen(ttf.getGlyphSet())
                 glf.draw(pen)
 
                 for cmd in pen._commands:


### PR DESCRIPTION
The original code was passing through the method, rather that the actual glyphset. 

This change fixes issues like this: https://github.com/gregdavill/KiBuzzard/issues/86