### PR TITLE
Parsing Units and Matrix Scaling Logic Updates

### DIFF
--- a/svg2mod/svg/svg.py
+++ b/svg2mod/svg/svg.py
@@ -455,13 +455,13 @@ class Matrix:
     def xscale(self):
         '''Return the rotated x scalar value'''
         if self.vect[0] == 0:
-            return 1
+            return abs(self.vect[2])
         else:
             return self.vect[0]/abs(self.vect[0]) * math.sqrt(self.vect[0]**2 + self.vect[2]**2)
     def yscale(self):
-        '''Return the rotated x scalar value'''
+        '''Return the rotated y scalar value'''
         if self.vect[3] == 0:
-            return 1
+            return abs(self.vect[1])
         else:
             return self.vect[3]/abs(self.vect[3]) * math.sqrt(self.vect[1]**2 + self.vect[3]**2)
     def rot(self):
@@ -1487,4 +1487,3 @@ for name, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
     tag = getattr(cls, 'tag', None)
     if tag:
         svgClass[svg_ns + tag] = cls
-


### PR DESCRIPTION
Bugs tackled:
- Parsing units string for scaling
- Division by Zero error when scaling

## Transform_styles parsing issue
Within svg2mod > svg > svg.py | transform_styles function
**Problem:** Regex parsing doesn't capture full values
**Solution:** Expand the regex pattern using "+" to capture more than one value

```python
has_units = re.search(r"\D",
```
`re.search` just matches the first character in the string and the `\D` will only catch the first non-digit.

Something like `1px` will return `p`, which won't match the appropriate key in `unit_convert`.

![image](https://github.com/user-attachments/assets/465b8e54-0b66-4136-bcb5-0e75acd57f0f)
I suspect this will resolve the posted Issue: 
[Path width export doesn't match Inkscape value · Issue #61 · svg2mod/svg2mod](https://github.com/svg2mod/svg2mod/issues/61)

The user reports an issue with scaling and in the post screenshot uses 'mm' (millimeters), which due to the `re.search(r"\D"` would not have gotten matched and scaled properly.

Additionally, the same problem occurs a few lines later here:
```python
float(re.search(r"\d", self.style[style]).group())
* unit_convert.get(unit, 1)
* ((matrix.xscale() + matrix.yscale()) / 2)
```
`re.search(r"\d", self.style[style]).group()` to grab the digits in front of the unit would only grab the first value. If it was a two digit number, `"22px"` for example would only return `2` as the value.

So this calculation would subsequently be wrong due to the first line.

The solution was just to add the "+" metacharacter for the regex to match more characters:
`\D+` and `\d+` respectively.

## Matrix xscale() and yscale() issues
Within svg2mod > svg > svg.py | xscale and yscale functions within Matrix class
**Problem:** ZeroDivisionError when denominator in formula is zero
**Solution:** Add an `if` check to return the default value in this case
```python
def xscale(self):
	"""Return the rotated x scalar value"""
	return (
		self.vect[0]
		/ abs(self.vect[0])
		* math.sqrt(self.vect[0] ** 2 + self.vect[2] ** 2)
	)

def yscale(self):
	"""Return the rotated y scalar value"""
	return (
		self.vect[3]
		/ abs(self.vect[3])
		* math.sqrt(self.vect[1] ** 2 + self.vect[3] ** 2)
	)
```

The issue is immediately apparent: the denominator in the calculation can throw a `ZeroDivisionError` if not properly handled.

I've encountered the exact issue when attempting to add a path to my SVG that has been mirrored along the X-axis and Y-axis, thus inputting a matrix of \[0.0, -1.0, -1.0, 0.0, 0.0, 0.0]
![Pasted image 20250224115436](https://github.com/user-attachments/assets/23cc9069-558b-4545-b51b-909215acd765)

The solution was to simply add a check for this case. For example:
![image](https://github.com/user-attachments/assets/f0fa1894-8e4b-4ccd-b72e-c2d7381326b1)
This is the formula for the logic and you can see that for the default case (where the identity matrix is used `vect = [1, 0, 0, 1, 0, 0]`) we pass a value of one in and get the positive value of `c`.

For more context to describe the problem,

The Inkscape SVG code is:
```
inkscape:label="whoami"
transform="matrix(0,-1,-1,0,0,0)"
```

`matrix(a, b, c, d, e, f)` is a way to represent a 2D transformation in SVG. Each parameter in the matrix plays a role in transforming the element.
- **a = 0**: No horizontal scaling.
- **b = -1**: Reflects over the x-axis and performs a 90-degree clockwise rotation.
- **c = -1**: Reflects over the y-axis and performs a 90-degree counterclockwise rotation.
- **d = 0**: No vertical scaling.
- **e = 0**: No horizontal translation.
- **f = 0**: No vertical translation.

```python
class Matrix:
    """SVG transformation matrix and its operations
    a SVG matrix is represented as a list of 6 values [a, b, c, d, e, f]
    (named vect hereafter) which represent the 3x3 matrix
    ((a, c, e)
     (b, d, f)
     (0, 0, 1))
    see http://www.w3.org/TR/SVG/coords.html#EstablishingANewUserSpace"""
```
This URL pointing to the W3 documentation isn't very helpful here.
The SVG documentation and definition for transform points to the CSS standard of the same thing:
[Coordinate Systems, Transformations and Units — SVG 2](https://www.w3.org/TR/SVG/coords.html#TransformProperty)
points to 
[CSS Transforms Module Level 1](https://www.w3.org/TR/css-transforms-1/)

These are pretty technical documents but do not concisely point out the implementation.
[matrix() - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix#values)
MDN has a clearer representation.

I suggest updating the docstring here to replace the last line to say:
SVGs implement the same transform that CSS does
see https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix#values