### PR TITLE
fix(update scaling technique to use absolute values)

### DIFF
--- a/svg2mod/svg/svg.py
+++ b/svg2mod/svg/svg.py
@@ -229,11 +229,13 @@ class Transformable:
         for style in self.transformable_styles:
             if self.style.get(style):
                 has_units = re.search(r'\D+', self.style[style] if isinstance(self.style[style], str) else '')
+                xscale = abs(matrix.xscale())
+                yscale = abs(matrix.yscale())
                 if has_units is None:
-                    self.style[style] = float(self.style[style]) * ((matrix.xscale()+matrix.yscale())/2)
+                    self.style[style] = float(self.style[style]) * ((xscale+yscale)/2)
                 else:
                     unit = has_units.group().lower()
-                    self.style[style] = float(re.search(r'\d+', self.style[style]).group()) * unit_convert.get(unit, 1) * ((matrix.xscale()+matrix.yscale())/2)
+                    self.style[style] = float(re.search(r'\d+', self.style[style]).group()) * unit_convert.get(unit, 1) * ((xscale+yscale)/2)
 
 
     def transform(self, matrix=None):


### PR DESCRIPTION
PROBLEM: https://github.com/svg2mod/svg2mod/issues/61

The user reports an issue with setting the stroke-width to any value and noticed:

> When I draw a line path on silkscreen and export it to a mod, the width of the trace in kicad is at the very minimum value.
> Even if I increment it in Inkscape, the value in Kicad doesn't match it.

SOLUTION:
To start with, I reproduced the issue but made it more obvious by scaling the SVG by some noticeable amount.

![Image](https://github.com/user-attachments/assets/d31afc5e-6007-408c-b5e7-4420b7fde6c2)

I thought I would try to scale the image by 10 times the original size and compare the SVG code.

![Image](https://github.com/user-attachments/assets/2f8b7d2d-d9ea-4dde-acdd-a65c12cf23b3)

As we can see, the only difference is the value set for `stroke-width`.

The issue stems from what's done within the svg.py > `transform_styles(self, matrix)` function.

With a transform: matrix [1.3333333, 0.0, 0.0, -1.3333333, 719.11653, 378.1448]

![Image](https://github.com/user-attachments/assets/1f0e7764-2b4b-4f71-a9d3-9b20667fff5e)

The calculation done in `transform_styles`, it seems we are trying to scale the style attribute proportionally to the average of the x and y scaling factors. 
Unfortunately, this specific case introduces a zero nullifying the whole attempt.

Considering that the negative value in this case is supposed to represent inverting the object, I took the absolute value from both scaling operations that is then used in the formulas. 

I could consider running a check for if the value is negative or something to avoid perhaps the "expensive" function call, but the code committed is the simplest solution to the problem.

As we can see, KiCad now reports the proper millimeters as seen in Inkscape:
![SUCCESS](https://github.com/user-attachments/assets/4da500e4-3a88-4980-9e40-5d9d4a651d49)
