### PR TITLE
WebAssembly Pyodide Implementation of svg2mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ output in KiCad's legacy or s-expression (i.e., pretty) formats.
 
 ## Requirements
 
-* Python 3
-* [fonttools](https://pypi.org/project/fonttools/)
+- Python 3
+- [fonttools](https://pypi.org/project/fonttools/)
 
 ## Installation
 
-```pip install svg2mod```
+`pip install svg2mod`
 
 ### Don't want to install the application?
 
 You can use a 3rd party web application instead:
 
-* [svg2mod.streamlitapp.com](https://inputblackboxoutput-streamlit-svg2mod-app-fszqih.streamlitapp.com/)
-* [svg2mod.com](https://svg2mod.com/)
+- [svg2mod.streamlitapp.com](https://inputblackboxoutput-streamlit-svg2mod-app-fszqih.streamlitapp.com/)
+- [svg2mod.com](https://svg2mod.com/)
 
 ## Showcase
 
@@ -44,7 +44,7 @@ If you have a project you are proud of please post about it on our
 
 ## Example
 
-```svg2mod input.svg```
+`svg2mod input.svg`
 
 ## Usage
 
@@ -98,53 +98,54 @@ optional arguments:
 svg2mod expects images saved in the uncompressed Inkscape SVG (i.e., not "plain SVG") format. This
 is so it can associate inkscape layers with kicad layers
 
-* Drawings should be to scale (1 mm in Inkscape will be 1 mm in KiCad).  Use the --factor option to
-resize the resulting module(s) up or down from there.
+- Drawings should be to scale (1 mm in Inkscape will be 1 mm in KiCad). Use the --factor option to
+  resize the resulting module(s) up or down from there.
 
-* Most elements are fully supported.
-  * A path may have an outline and a fill.  (Colors will be ignored.)
-  * A path may have holes, defined by interior segments within the path (see included examples).
-  * 100% Transparent fills and strokes with be ignored.
-  * Text Elements are partially supported
-* Groups may be used. Styles applied to groups (e.g., stroke-width) are applied to contained drawing
+- Most elements are fully supported.
+  - A path may have an outline and a fill. (Colors will be ignored.)
+  - A path may have holes, defined by interior segments within the path (see included examples).
+  - 100% Transparent fills and strokes with be ignored.
+  - Text Elements are partially supported
+- Groups may be used. Styles applied to groups (e.g., stroke-width) are applied to contained drawing
   elements.
 
-* Layers or items must be named to match the target in kicad. The supported layers are listed below.
+- Layers or items must be named to match the target in kicad. The supported layers are listed below.
   They will be ignored otherwise.
-  * These are pulled from `inkscape:label` but will pull from `id` if the label isn't set.
 
-* __If there is an issue parsing an inkscape object or stroke convert it to a path.__
-  * __Use Inkscape's "Path->Object To Path" and "Path->Stroke To Path" menu options to convert these__
-    __elements into paths that will work.__
+  - These are pulled from `inkscape:label` but will pull from `id` if the label isn't set.
+
+- **If there is an issue parsing an inkscape object or stroke convert it to a path.**
+  - **Use Inkscape's "Path->Object To Path" and "Path->Stroke To Path" menu options to convert these**
+    **elements into paths that will work.**
 
 ### Layers
 
 This supports the layers listed below. They are the same in inkscape and kicad:
 
-| KiCad layer(s)       | KiCad legacy | KiCad pretty |
-|:--------------------:|:------------:|:------------:|
-| F.Cu [^1]            | Yes          | Yes          |
-| B.Cu [^1]            | Yes          | Yes          |
-| F.Adhes              | Yes          | Yes          |
-| B.Adhes              | Yes          | Yes          |
-| F.Paste              | Yes          | Yes          |
-| B.Paste              | Yes          | Yes          |
-| F.SilkS              | Yes          | Yes          |
-| B.SilkS              | Yes          | Yes          |
-| F.Mask               | Yes          | Yes          |
-| B.Mask               | Yes          | Yes          |
-| Dwgs.User            | Yes          | Yes          |
-| Cmts.User            | Yes          | Yes          |
-| Eco1.User            | Yes          | Yes          |
-| Eco2.User            | Yes          | Yes          |
-| Edge.Cuts            | Yes          | Yes          |
-| F.Fab                | --           | Yes          |
-| B.Fab                | --           | Yes          |
-| F.CrtYd              | --           | Yes          |
-| B.CrtYd              | --           | Yes          |
-| Drill.Cu [^1] [^2]   | --           | Yes          |
-| Drill.Mech [^1] [^2] | --           | Yes          |
-| *.Keepout [^1] [^4]  | --           | Yes [^3]     |
+|    KiCad layer(s)    | KiCad legacy | KiCad pretty |
+| :------------------: | :----------: | :----------: |
+|      F.Cu [^1]       |     Yes      |     Yes      |
+|      B.Cu [^1]       |     Yes      |     Yes      |
+|       F.Adhes        |     Yes      |     Yes      |
+|       B.Adhes        |     Yes      |     Yes      |
+|       F.Paste        |     Yes      |     Yes      |
+|       B.Paste        |     Yes      |     Yes      |
+|       F.SilkS        |     Yes      |     Yes      |
+|       B.SilkS        |     Yes      |     Yes      |
+|        F.Mask        |     Yes      |     Yes      |
+|        B.Mask        |     Yes      |     Yes      |
+|      Dwgs.User       |     Yes      |     Yes      |
+|      Cmts.User       |     Yes      |     Yes      |
+|      Eco1.User       |     Yes      |     Yes      |
+|      Eco2.User       |     Yes      |     Yes      |
+|      Edge.Cuts       |     Yes      |     Yes      |
+|        F.Fab         |      --      |     Yes      |
+|        B.Fab         |      --      |     Yes      |
+|       F.CrtYd        |      --      |     Yes      |
+|       B.CrtYd        |      --      |     Yes      |
+|  Drill.Cu [^1] [^2]  |      --      |     Yes      |
+| Drill.Mech [^1] [^2] |      --      |     Yes      |
+| \*.Keepout [^1] [^4] |      --      |   Yes [^3]   |
 
 Note: If you have a layer `F.Cu`, all of its sub-layers will be treated as `F.Cu` regardless of their
 names.
@@ -164,35 +165,32 @@ Ex: `F.Cu:pad;...`
 
 Supported Arguments:
 
-* Pad
-  
+- Pad
+
   Any copper layer can have the pad specified.
   The pad option can be used solo (`F.Cu:Pad`) or it can also have it's own arguments.
   The arguments are:
 
-  * Number
+  - Number
     If it is set it will specify the number of the pad. Ex: `Pad:1`
 
-  * Paste _(Not available for `Drill.Cu`)_
-  * Mask _(Not available for `Drill.Cu`)_
+  - Paste _(Not available for `Drill.Cu`)_
+  - Mask _(Not available for `Drill.Cu`)_
 
-* Allowed
-  
+- Allowed
+
   Keepout areas will prevent anything from being placed inside them.
   To allow some things to be placed inside the keepout zone a comma
   separated list of any of the following options can be used:
   `tracks`,`vias`,`pads`,`copperpour`,`footprints`
-  
-* Hatch
+
+- Hatch
 
   Keepout areas have different hatching styles. This allows customization
   of the appearance of hatching when converting from an svg, Ex: `F.Keepout:Hatch:edge`.
   All available hatch options are `none`, `edge`, `full`.
-  
+
 [^1]: These layers can have arguments when svg2mod is in pretty mode
-
 [^2]: Drills can only be svg circle objects. The stroke width in `Drill.Cu` is the pad size and the fill is the drill size.
-
 [^3]: Only works in Kicad versions >= v6 (`--format latest`).
-
 [^4]: The \* can be { \*, F, B, I } or any combination like FB or BI. These options are for Front, Back, and Internal.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ output in KiCad's legacy or s-expression (i.e., pretty) formats.
 
 ### Don't want to install the application?
 
-You can use a 3rd party web application instead:
-
-- [svg2mod.streamlitapp.com](https://inputblackboxoutput-streamlit-svg2mod-app-fszqih.streamlitapp.com/)
-- [svg2mod.com](https://svg2mod.com/)
+Within the `www` directory download the `index.html` and `app.js` files and launching the `index.html` file with any browser (or clone the repo and do the same locally). The logic just runs svg2mod via WebAssembly.
 
 ## Showcase
 

--- a/www/app.js
+++ b/www/app.js
@@ -1,0 +1,164 @@
+let pyodide;
+let setupComplete = false;
+
+async function setup() {
+  const logElement = document.getElementById("outputLog");
+
+  // Helper to append text to the log element
+  const addToLog = text => {
+    logElement.innerText += text + "\n";
+    // Optional: Auto-scroll to the bottom
+    logElement.scrollTop = logElement.scrollHeight;
+  };
+
+  // Initialize Pyodide with stdout/stderr redirection
+  pyodide = await loadPyodide({
+    stdout: text => {
+      console.log(text);
+      addToLog(text);
+    },
+    stderr: text => {
+      console.error(text);
+      addToLog(`[ERROR] ${text}`);
+    },
+  });
+  // Load micropip to install the svg2mod package
+  await pyodide.loadPackage("micropip");
+  const micropip = pyodide.pyimport("micropip");
+
+  // Install svg2mod and its dependencies
+  await micropip.install("svg2mod");
+
+  document.getElementById("status").innerText = "Status: Ready";
+
+  const fileInput = document.getElementById("svgInput");
+  if (fileInput.files.length !== 0) {
+    setupComplete = true;
+    document.getElementById("convertBtn").disabled = false;
+  }
+}
+
+setup();
+
+document.getElementById("svgInput").onchange = event => {
+  if (event.target.files.length > 0) {
+    setupComplete = true;
+    document.getElementById("convertBtn").disabled = false;
+  }
+};
+
+document.getElementById("convertBtn").onclick = async () => {
+  const fileInput = document.getElementById("svgInput");
+  if (fileInput.files.length === 0) return;
+
+  if (!setupComplete) {
+    status.innerText = "Status: Setup not complete.";
+    return;
+  }
+
+  const file = fileInput.files[0];
+  const svgText = await file.text();
+  const status = document.getElementById("status");
+
+  status.innerText = "Status: Converting...";
+
+  // Clear previous error messages
+  const errorOutput = document.getElementById("errorOutput");
+  errorOutput.innerText = "";
+  const errorDiv = document.getElementById("errorDiv");
+  errorDiv.hidden = true;
+
+  // Clear previous log output
+  document.getElementById("outputLog").innerText = "";
+
+  // Gather optional parameters (if any)
+  const outputModuleName = document.getElementById("output").value || "svg2mod";
+  const moduleValue = document.getElementById("moduleValue").value || "G***";
+  const scale = parseFloat(document.getElementById("scale").value) || 1.0;
+  const precision =
+    parseFloat(document.getElementById("precision").value) || 5.0;
+  const dpi = parseInt(document.getElementById("dpi").value) || 96;
+  const centered = document.getElementById("center").checked;
+  const excludeHidden = document.getElementById("excludeHidden").checked;
+  const convertPads = document.getElementById("convertPads").checked;
+  const forceLayer = document.getElementById("forceLayer").value || null;
+
+  try {
+    // 1. Write the SVG content to Pyodide's virtual file system
+    pyodide.FS.writeFile("input.svg", svgText);
+
+    // 2. Expose JS variables to Python globals
+    // This makes these variables accessible by name in your Python script
+    pyodide.globals.set("outputModuleName", outputModuleName);
+    pyodide.globals.set("moduleValue", moduleValue);
+    pyodide.globals.set("scale", scale);
+    pyodide.globals.set("precision", precision);
+    pyodide.globals.set("dpi", dpi);
+    pyodide.globals.set("centered", centered);
+    pyodide.globals.set("excludeHidden", excludeHidden);
+    pyodide.globals.set("convertPads", convertPads);
+    pyodide.globals.set("forceLayer", forceLayer);
+
+    // 2. Run the svg2mod conversion logic via Python
+    // We use the library interface of svg2mod rather than the CLI
+    await pyodide.runPythonAsync(`
+            from svg2mod.svg.svg import Text
+            from svg2mod.exporter import Svg2ModExportLatest, Svg2ModImport
+
+            # FIX: The library doesn't know about Emscripten font paths.
+            # We tell it to use the same (empty) list as Windows/Linux
+            # so it doesn't throw a KeyError.
+            if 'Emscripten' not in Text._os_font_paths:
+                Text._os_font_paths['Emscripten'] = []
+
+            # Mirroring the logic in cli.py:
+
+            # 1. Replicating the 'imported' logic
+            # This parses the SVG file first
+            imported = Svg2ModImport(
+                "input.svg",
+                module_name=outputModuleName,
+                module_value=moduleValue,
+                ignore_hidden=excludeHidden,
+                force_layer=forceLayer
+            )
+
+            # 2. Instantiate Svg2Mod with the parameters cli.py usually parses
+            exported = Svg2ModExportLatest(
+                imported,
+                outputModuleName + ".kicad_mod",
+                centered,
+                scale,
+                precision,
+                dpi = dpi,
+                pads = convertPads
+            )
+
+            # 2. The cli.py calls .write(), which triggers the internal parser
+            # and writes the KiCad formatted strings to the output file.
+            exported.write()
+        `);
+
+    // 3. Read the generated .mod file back into JavaScript
+    const modData = pyodide.FS.readFile(outputModuleName + ".kicad_mod");
+
+    // 4. Trigger the download
+    downloadBlob(modData, file.name.replace(".svg", ".kicad_mod"));
+    status.innerText = "Status: Done!";
+  } catch (err) {
+    console.error(err);
+    status.innerText = "Status: Error during conversion.";
+    errorOutput.innerText = err.toString();
+    errorDiv.hidden = false;
+  }
+};
+
+function downloadBlob(data, fileName) {
+  const blob = new Blob([data], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>SVG to KiCad Converter</title>
+  <script src="https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: #f5f5f5;
+      color: #333;
+      line-height: 1.6;
+    }
+
+    h1 {
+      color: #2c3e50;
+      margin-bottom: 0.5rem;
+    }
+
+    h2 {
+      font-size: 1rem;
+      font-weight: normal;
+      color: #7f8c8d;
+      margin-bottom: 1.5rem;
+    }
+
+    h3 {
+      color: #34495e;
+      margin-bottom: 1rem;
+      font-size: 1.1rem;
+    }
+
+    input[type="file"] {
+      margin-bottom: 1rem;
+      padding: 0.5rem;
+      border: 2px dashed #bdc3c7;
+      border-radius: 4px;
+      background: white;
+      width: 100%;
+      cursor: pointer;
+    }
+
+    button {
+      background: #3498db;
+      color: white;
+      border: none;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 1rem;
+      margin-bottom: 2rem;
+      transition: background 0.3s;
+    }
+
+    button:hover:not(:disabled) {
+      background: #2980b9;
+    }
+
+    button:disabled {
+      background: #95a5a6;
+      cursor: not-allowed;
+      opacity: 0.6;
+      filter: grayscale(0.5);
+    }
+
+    div {
+      background: white;
+      padding: 1.5rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    label {
+      display: inline-block;
+      margin-bottom: 0.25rem;
+      color: #555;
+      font-weight: 500;
+    }
+
+    input[type="text"],
+    input[type="number"] {
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 0.95rem;
+      width: 200px;
+    }
+
+    input[type="text"]:focus,
+    input[type="number"]:focus {
+      outline: none;
+      border-color: #3498db;
+    }
+
+    input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+      cursor: pointer;
+    }
+
+    br+br {
+      display: block;
+      content: "";
+      margin-top: 0.5rem;
+    }
+
+    #errorDiv {
+      margin-bottom: 1.5rem;
+      border: 1px solid #e74c3c;
+      background: #fdecea;
+    }
+
+    #errorOutput {
+      height: 150px;
+      overflow-y: auto;
+      padding: 1rem;
+      border-radius: 4px;
+      font-family: monospace;
+    }
+
+    #outputDiv {
+      margin-bottom: 2rem;
+      border: 1px solid #2ecc71;
+      background: #eafaf1;
+    }
+
+    #outputLog {
+      height: 200px;
+      overflow-y: auto;
+      padding: 1rem;
+      border-radius: 4px;
+      font-family: monospace;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>SVG to KiCad (.mod) Converter</h1>
+  <h2 id="status">Status: Initializing...</h2>
+  <input type="file" id="svgInput" accept=".svg">
+  <button id="convertBtn" disabled>Run svg2mod</button>
+
+  <div id="errorDiv" hidden>
+    <h3>Error Messages:</h3>
+    <pre id="errorOutput" style="color: red; white-space: pre-wrap;"></pre>
+  </div>
+
+  <div id="outputDiv">
+    <h3>Output:</h3>
+    <pre id="outputLog" style="white-space: pre-wrap;"></pre>
+  </div>
+
+  <div>
+    <h3>Optional Parameters</h3>
+
+    <label for="output">Output Module Name (default svg2mod): </label>
+    <input type="text" id="output" placeholder="svg2mod"><br><br>
+
+    <label for="moduleValue">Module Value (default G***): </label>
+    <input type="text" id="moduleValue" placeholder="G***"><br><br>
+
+    <label for="scale">Scaling Factor (default 1.0): </label>
+    <input type="number" id="scale" step="0.1" value="1.0"><br><br>
+
+    <label for="precision">Precision (default 5): </label>
+    <input type="number" id="precision" value="5"><br><br>
+
+    <label for="dpi">DPI (default 96): </label>
+    <input type="number" id="dpi" value="96"><br><br>
+
+    <label for="center">Center the module to the center of the bounding box (default false): </label>
+    <input type="checkbox" id="center"><br><br>
+
+    <label for="excludeHidden">Do not export hidden objects (default false): </label>
+    <input type="checkbox" id="excludeHidden"><br><br>
+
+    <label for="convertPads">Convert any artwork on Cu layers to pads (default false): </label>
+    <input type="checkbox" id="convertPads"><br><br>
+
+    <label for="forceLayer">Force everything into the single provided layer (default none): </label>
+    <input type="text" id="forceLayer"><br><br>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Within the README.md, there are two references to 3rd party websites that implement the same functionality as running svg2mod via CLI.

Sadly, the first domain svg2mod.streamlitapp.com no longer works:
<img width="880" height="412" alt="image" src="https://github.com/user-attachments/assets/d818d330-8ac9-47f5-acee-9d9f8ea11eb0" />

And the second is honestly not that intuitive to use.

## Solution

With the power of WebAssembly, it is fairly easy to load the project onto a web page without the need for some "backend" server (i.e. an AWS Lambda or Azure Function).

Here is what the simple web page looks like on first load:
<img width="834" height="1284" alt="image" src="https://github.com/user-attachments/assets/c4a3b778-2fd3-47a5-81d3-d9ddbaf29791" />

Here is what a successful conversion looks like (after clicking run, you are prompted to download the resulting file):
<img width="1013" height="1250" alt="image" src="https://github.com/user-attachments/assets/b37b3016-f8d4-46e1-b229-9c34daf4492f" />

You can see all the traditional logs you'd see within the CLI are presented on the frontend.

Here is an example of running into an error:
<img width="812" height="819" alt="image" src="https://github.com/user-attachments/assets/33f661dd-1741-47e6-bc73-e24059bb7976" />

I propose to just include two basic files in the project: `index.html` and `app.js`.
The HTML file just has the basic fields that cover what flags exist for CLI arguments, output and error logs, and finally an element to allow an SVG to be "uploaded".

I am leveraging Pyodide, a Python distribution for the browser and Node.js based on WebAssembly.

You can see that we are able to mirror the logic in `cli.py` of svg2mod:
<img width="784" height="1297" alt="image" src="https://github.com/user-attachments/assets/a60c94fa-9451-4020-bb4b-8554c6137436" />

I'm hoping this approach removes any dependencies on hosting stuff, needing a domain, etc.

The only con for the approach is the dependency on Pyodide sourced at a specific version as coded in the `index.html` file:
```js
<script src="https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js"></script>
```
I probably could download this Pyodide JS file to include in this PR to remove any external dependency and secure the longevity of this approach, but then it's not as easy to update the version if necessary.