### PR TITLE
Compatibility with non-inkscape SVG generators like Affinity Designer: Fix assignment of self.name to self.id to support SVGs not rendered with Inkscape

### DIFF
--- a/svg2mod/svg/svg.py
+++ b/svg2mod/svg/svg.py
@@ -106,7 +106,7 @@ class Transformable:
                     break
             # self.name isn't set so try setting name to id
             if self.name == '':
-                self.name == self.id
+                self.name = self.id
 
             # set fill_even_odd if property set
             self.fill_even_odd = elt.get("fill-rule", '').lower() == 'evenodd'


### PR DESCRIPTION
I tried to convert an svg not created by Inkscape, but with Affinity Designer. It would not parse. 
The fallback to "id" does not work as it compares 2 values instead of assign the id to the name value